### PR TITLE
Upate swig to 4.1.1

### DIFF
--- a/org.freedesktop.Sdk.Extension.llvm16.json
+++ b/org.freedesktop.Sdk.Extension.llvm16.json
@@ -23,8 +23,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.sourceforge.net/swig/swig-4.0.2.tar.gz",
-          "sha256": "d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
+          "url": "https://download.sourceforge.net/swig/swig-4.1.1.tar.gz",
+          "sha256": "2af08aced8fcd65cdb5cc62426768914bedc735b1c250325203716f78e39ac9b"
         }
       ]
     },


### PR DESCRIPTION
Older swig requires pcre while next 23.08 runtime ships only pcre2